### PR TITLE
Create object in callable case

### DIFF
--- a/StubsController.php
+++ b/StubsController.php
@@ -86,7 +86,7 @@ TPL;
 
                     if (is_callable($definition, true)) {
                         try{
-                            $definition = \Yii::$app->get($name, false);
+                            $definition = \Yii::createObject($definition);
                         } catch(\Exception $exception){
                             continue;
                         }


### PR DESCRIPTION
Configuration of console application may be different. So ``\Yii::$app->get($name, false);`` returns nothing